### PR TITLE
renameFileFn dont work unless replaceFileNameFn is defined

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -160,7 +160,7 @@ async function createNew(_context, isRenameTemplate) {
       /**
        * @deprecated `replaceFileNameFn` is deprecated, using `renameFileFn`
        */
-      config.replaceFileNameFn && config.renameFileFn,
+      config.renameFileFn || config.replaceFileNameFn,
       config.renameSubDirectoriesFn
     );
     vscode.window.showInformationMessage("Template: copied!");


### PR DESCRIPTION
config.renameFileFn dont work if config.replaceFileNameFn is evaluated to false
deprecated config.replaceFileNameFn is never applied